### PR TITLE
[PR] Replace custom wp_install_defaults() with wpmu_new_blog hooks

### DIFF
--- a/includes/wsuwp-mu-new-site-defaults.php
+++ b/includes/wsuwp-mu-new-site-defaults.php
@@ -2,9 +2,10 @@
 
 namespace WSUWP\New_Site_Defaults;
 
-add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_site_defaults', 10 );
-add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_project_site_defaults', 11, 3 ); // project.wsu.edu
-add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_sites_site_defaults', 11, 3 );   // sites.wsu.edu
+add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_site_defaults', 11 );
+add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_project_site_defaults', 12, 3 );      // project.wsu.edu
+add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_sites_site_defaults', 12, 3 );        // sites.wsu.edu
+add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_crimsonpages_site_defaults', 10, 3 ); // crimpsonpages.org
 
 /**
  * Set the defaults used by sites created on the WSUWP Platform.
@@ -12,7 +13,6 @@ add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_sites_site_defaults', 
  * @since 0.0.1
  */
 function set_site_defaults( $site_id ) {
-
 	switch_to_blog( $site_id );
 
 	// Update the default category name to "General" from "Uncategorized".
@@ -180,7 +180,7 @@ function set_project_site_defaults( $site_id, $user_id, $domain ) {
  */
 function set_sites_site_defaults( $site_id, $user_id, $domain ) {
 
-	// Only apply these defaults to sites sites. ;)
+	// Only apply these defaults to sites sites.
 	if ( ! in_array( $domain, array( 'sites.wsu.edu', 'sites.wsu.dev' ), true ) ) {
 		return;
 	}
@@ -206,6 +206,37 @@ function set_sites_site_defaults( $site_id, $user_id, $domain ) {
 	}
 
 	wp_cache_delete( 'alloptions', 'options' );
+	restore_current_blog();
+
+	clean_blog_cache( $site_id );
+}
+
+/**
+ * Preconfigure a Crimson Pages student portfolio site to reduce the overall
+ * setup experience.
+ *
+ * @since 0.0.1
+ *
+ * @param int    $site_id ID of the site being created.
+ * @param int    $user_id ID of the user creating the site.
+ * @param string $domain  Domain of the site being created.
+ */
+function set_crimsonpages_site_defaults( $site_id, $user_id, $domain ) {
+
+	// Only apply these defaults to Crimson Pages sites.
+	if ( ! in_array( $domain, array( 'crimsonpages.org', 'crimsonpages.dev', 'crimsonpages.test' ), true ) ) {
+		return;
+	}
+
+	// Remove several things we do for new WSU branded sites.
+	remove_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_site_defaults', 11 );
+
+	switch_to_blog( $site_id );
+
+	// Activate Twenty Seventeen by default.
+	update_option( 'stylesheet', 'twentyseventeen' );
+	update_option( 'template', 'twentyseventeen' );
+
 	restore_current_blog();
 
 	clean_blog_cache( $site_id );

--- a/includes/wsuwp-mu-new-site-defaults.php
+++ b/includes/wsuwp-mu-new-site-defaults.php
@@ -6,6 +6,7 @@ add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_site_defaults', 11 );
 add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_project_site_defaults', 12, 3 );      // project.wsu.edu
 add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_sites_site_defaults', 12, 3 );        // sites.wsu.edu
 add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_crimsonpages_site_defaults', 10, 3 ); // crimpsonpages.org
+add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\delete_rewrite_rules', 99 );
 
 /**
  * Set the defaults used by sites created on the WSUWP Platform.
@@ -240,4 +241,15 @@ function set_crimsonpages_site_defaults( $site_id, $user_id, $domain ) {
 	restore_current_blog();
 
 	clean_blog_cache( $site_id );
+}
+
+/**
+ * Flush the rewrite rules immediately after site creation.
+ *
+ * @since 0.0.1
+ *
+ * @param int $site_id ID of the site being created.
+ */
+function delete_rewrite_rules( $site_id ) {
+	delete_blog_option( $site_id, 'rewrite_rules' );
 }

--- a/includes/wsuwp-mu-new-site-defaults.php
+++ b/includes/wsuwp-mu-new-site-defaults.php
@@ -24,14 +24,14 @@ function set_site_defaults( $site_id ) {
 
 	// Update the title of the first post created by WordPress, "Hello World".
 	wp_update_post( array(
-		1,
+		'ID' => 1,
 		'post_title' => apply_filters( 'wsuwp_first_title', 'Sample Post' ),
 		'post_content' => apply_filters( 'wsuwp_first_post_content', '' ),
 	) );
 
 	// Update the title of the first page created by WordPress, "Sample Page".
 	wp_update_post( array(
-		2,
+		'ID' => 2,
 		'post_title' => apply_filters( 'wsuwp_first_page_title', 'Home Page' ),
 		'post_content' => apply_filters( 'wsuwp_first_page_content', '' ),
 	) );

--- a/includes/wsuwp-mu-new-site-defaults.php
+++ b/includes/wsuwp-mu-new-site-defaults.php
@@ -20,7 +20,7 @@ function set_site_defaults( $site_id ) {
 	) );
 
 	// Delete the first comment auto-created by WordPress during install.
-	wp_delete_comment( 1 );
+	wp_delete_comment( 1, true );
 
 	// Update the title of the first post created by WordPress, "Hello World".
 	wp_update_post( array(

--- a/includes/wsuwp-mu-new-site-defaults.php
+++ b/includes/wsuwp-mu-new-site-defaults.php
@@ -1,12 +1,75 @@
 <?php
 
-namespace WSUWP\Plugin_Skeleton;
+namespace WSUWP\New_Site_Defaults;
 
-add_action( 'after_setup_theme', 'WSUWP\Plugin_Skeleton\bootstrap' );
+add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_site_defaults', 10 );
+
 /**
- * Starts things up.
+ * Set the defaults used by sites created on the WSUWP Platform.
  *
  * @since 0.0.1
  */
-function bootstrap() {
+function set_site_defaults() {
+
+	// Update the default category name to "General" from "Uncategorized".
+	wp_update_term( 1, 'category', array(
+		'name' => 'General',
+		'slug' => 'general',
+	) );
+
+	// Delete the first comment auto-created by WordPress during install.
+	wp_delete_comment( 1 );
+
+	// Update the title of the first post created by WordPress, "Hello World".
+	wp_update_post( array(
+		1,
+		'post_title' => apply_filters( 'wsuwp_first_title', 'Sample Post' ),
+		'post_content' => apply_filters( 'wsuwp_first_post_content', '' ),
+	) );
+
+	// Update the title of the first page created by WordPress, "Sample Page".
+	wp_update_post( array(
+		2,
+		'post_title' => apply_filters( 'wsuwp_first_page_title', 'Home Page' ),
+		'post_content' => apply_filters( 'wsuwp_first_page_content', '' ),
+	) );
+
+	// Add a new "News" page to be used for showing posts.
+	$post_id = wp_insert_post( array(
+		'post_type' => 'page',
+		'post_title' => 'News',
+		'post_content' => 'This is a placeholder page for news items. Editing is not recommended.',
+	) );
+
+	// Set the "Page on Front" setting by default.
+	update_option( 'show_on_front', 'page' );
+
+	// Set the page on front to the home page.
+	update_option( 'page_on_front', 2 );
+
+	// Set the page for posts to the News page.
+	update_option( 'page_for_posts', (int) $post_id );
+
+	// Set a default, but filtered site description for WSU sites.
+	update_option( 'blogdescription', apply_filters( 'wsuwp_install_site_description', 'A WSU WordPress Site' ) );
+
+	// Set a default, but filtered timezone for Pacific time.
+	update_option( 'timezone_string', apply_filters( 'wsuwp_install_default_timezone_string', 'America/Los_Angeles' ) );
+
+	// Setup default image sizes, allowing them to be filtered.
+	$default_image_sizes = array(
+		'thumbnail_size_w' => 198,
+		'thumbnail_size_h' => 198,
+		'medium_size_w'    => 396,
+		'medium_size_h'    => 99164,
+		'large_size_w'     => 792,
+		'large_size_h'     => 99164,
+	);
+	$image_sizes = apply_filters( 'wsuwp_install_default_image_sizes', $default_image_sizes );
+
+	foreach ( $image_sizes as $size => $val ) {
+		if ( array_key_exists( $size, $default_image_sizes ) ) {
+			update_option( $size, absint( $val ) );
+		}
+	}
 }

--- a/includes/wsuwp-mu-new-site-defaults.php
+++ b/includes/wsuwp-mu-new-site-defaults.php
@@ -9,7 +9,9 @@ add_action( 'wpmu_new_blog', 'WSUWP\New_Site_Defaults\set_site_defaults', 10 );
  *
  * @since 0.0.1
  */
-function set_site_defaults() {
+function set_site_defaults( $site_id ) {
+
+	switch_to_blog( $site_id );
 
 	// Update the default category name to "General" from "Uncategorized".
 	wp_update_term( 1, 'category', array(
@@ -72,4 +74,6 @@ function set_site_defaults() {
 			update_option( $size, absint( $val ) );
 		}
 	}
+
+	restore_current_blog();
 }


### PR DESCRIPTION
This replaces the functionality in other places with a single plugin to keep new site configuration in the same place.

See also:
* https://github.com/washingtonstateuniversity/WSUWP-Platform/pull/435
* https://github.com/washingtonstateuniversity/WSUWP-Admin/pull/140
* https://github.com/washingtonstateuniversity/WSUWP-Plugin-Multiple-Networks/pull/18
